### PR TITLE
Bump junit from 4.13.1 to 4.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR updates `junit` from `4.13.1` to `4.13.2`.